### PR TITLE
Added query string for POST /users

### DIFF
--- a/src/main/java/unicon/matthews/oneroster/service/UserService.java
+++ b/src/main/java/unicon/matthews/oneroster/service/UserService.java
@@ -66,33 +66,28 @@ public class UserService {
 
 
 
-  public User save(final String tenantId, final String orgId, User user) {
-    if (StringUtils.isBlank(tenantId)
-            || StringUtils.isBlank(orgId)
-            || user == null) {
+  public User save(final String tenantId, final String orgId, User user, boolean check) {
+    if (StringUtils.isBlank(tenantId) || StringUtils.isBlank(orgId) || user == null)
       throw new IllegalArgumentException();
-    }
 
-    MongoUser existingMongoUser
-            = mongoUserRepository.findByTenantIdAndOrgIdAndUserSourcedIdIgnoreCase(tenantId, orgId, user.getSourcedId());
-    MongoUser mongoUserToSave = null;
+    MongoUser mongoUserToSave, existingMongoUser = null;
+
+    if (check)
+      existingMongoUser = mongoUserRepository.findByTenantIdAndOrgIdAndUserSourcedIdIgnoreCase(tenantId, orgId, user.getSourcedId());
 
     if (existingMongoUser == null) {
-      mongoUserToSave =
-              new MongoUser.Builder()
-                      .withTenantId(tenantId)
-                      .withOrgId(orgId)
-                      .withUser(fromUser(user, tenantId))
-                      .build();
-    }
-    else {
-      mongoUserToSave =
-              new MongoUser.Builder()
-                      .withId(existingMongoUser.getId())
-                      .withTenantId(tenantId)
-                      .withOrgId(orgId)
-                      .withUser(fromUser(user, tenantId))
-                      .build();
+      mongoUserToSave = new MongoUser.Builder()
+              .withTenantId(tenantId)
+              .withOrgId(orgId)
+              .withUser(fromUser(user, tenantId))
+              .build();
+    } else {
+      mongoUserToSave = new MongoUser.Builder()
+              .withId(existingMongoUser.getId())
+              .withTenantId(tenantId)
+              .withOrgId(orgId)
+              .withUser(fromUser(user, tenantId))
+              .build();
     }
 
     MongoUser saved = mongoUserRepository.save(mongoUserToSave);

--- a/src/test/java/unicon/matthews/oneroster/service/UserServiceTest.java
+++ b/src/test/java/unicon/matthews/oneroster/service/UserServiceTest.java
@@ -40,7 +40,7 @@ public class UserServiceTest {
         .withSourcedId("user-sid")
         .build();
     
-    User savedUser = unit.save("tenant-1","org-1",user);
+    User savedUser = unit.save("tenant-1","org-1",user, true);
     assertThat(savedUser, is(notNullValue()));
     assertThat(savedUser.getSourcedId(), is(notNullValue()));
   }
@@ -53,7 +53,7 @@ public class UserServiceTest {
         .withSourcedId("user-sid")
         .build();
     
-    unit.save("tenant-1","org-1",user);
+    unit.save("tenant-1","org-1",user, true);
 
     User found = unit.findBySourcedId("tenant-1","org-1", "user-sid");
     


### PR DESCRIPTION
Due to the amount of users that we have, this endpoint took a pretty long time (when we populated the DB) because of the duplicate checking.
I added a query filter (optional) to skip it.

### Concerned Route
|    HTTP Method     |     URI Path      |   Description    |
|:------------------:|:--------------:|:--------------|
| POST          |    /api/users/        |   Added optional query filter `?check=boolean`|


