### PR TITLE
Typo in curl login example

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,8 @@ Find the values apiKey and apiSecret, those are the values you'll need to use to
 
 ```bash
 curl -X POST -H "X-Requested-With: XMLHttpRequest" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{  
-    "username": USERNAME",
-    "password": PORT
-}' "http://localhost:9966/api/auth/login"
+    "username": "USERNAME",
+    "password": "PASSWORD"}' "http://localhost:9966/api/auth/login"
 ```
 
 <br>


### PR DESCRIPTION
I was testing this out and there were some issues with the curl example running. The python was very helpful!